### PR TITLE
Update rancher/shell to release version v0.1.18

### DIFF
--- a/charts/helm-project-operator/values.yaml
+++ b/charts/helm-project-operator/values.yaml
@@ -177,7 +177,7 @@ debugLevel: 0
 cleanup:
   image:
     repository: rancher/shell
-    tag: v0.1.18-rc8
+    tag: v0.1.18
 
   nodeSelector: {}
 


### PR DESCRIPTION
Update rancher/shell version to a non-rc to use SLE-BCI base image.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>