### PR TITLE
Use correct link to download golangci-lint

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -7,7 +7,8 @@
 			"goimports",
 			"misspell",
 			"ineffassign",
-			"gofmt"
+			"gofmt",
+			"staticcheck"
 		]
 	},
 	"run": {

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -11,7 +11,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 RUN zypper -n install git docker vim less file curl wget
 RUN go install golang.org/x/tools/cmd/goimports@latest
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.51.1; \
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.2; \
     fi
 
 ENV YQ_VERSION=v4.30.8

--- a/pkg/applier/applyinator.go
+++ b/pkg/applier/applyinator.go
@@ -36,7 +36,6 @@ type Options struct {
 // will only be processed once.
 // * Multiple consumers and producers. In particular, it is allowed for an
 // item to be reenqueued while it is being processed.
-//
 type Applyinator interface {
 	Apply(key string)
 	Run(ctx context.Context, workers int)
@@ -52,7 +51,6 @@ type Applyinator interface {
 // will only be processed once.
 // * Multiple consumers and producers. In particular, it is allowed for an
 // item to be reenqueued while it is being processed.
-//
 func NewApplyinator(name string, applyFunc ApplyFunc, opts *Options) Applyinator {
 	opts = applyDefaultOptions(opts)
 	return &applyinator{

--- a/pkg/controllers/common/hardening.go
+++ b/pkg/controllers/common/hardening.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -46,7 +45,7 @@ func LoadHardeningOptionsFromFile(path string) (HardeningOptions, error) {
 		}
 		return HardeningOptions{}, err
 	}
-	hardeningOptionsBytes, err := ioutil.ReadFile(abspath)
+	hardeningOptionsBytes, err := os.ReadFile(abspath)
 	if err != nil {
 		return hardeningOptions, err
 	}

--- a/pkg/controllers/common/runtime.go
+++ b/pkg/controllers/common/runtime.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -152,7 +151,7 @@ func LoadValuesOverrideFromFile(path string) (v1alpha1.GenericMap, error) {
 		}
 		return nil, err
 	}
-	valuesOverrideBytes, err := ioutil.ReadFile(abspath)
+	valuesOverrideBytes, err := os.ReadFile(abspath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/project/resources.go
+++ b/pkg/controllers/project/resources.go
@@ -77,7 +77,9 @@ func (h *handler) getProjectReleaseNamespace(projectID string, isOrphaned bool, 
 
 // getRoleBindings returns the RoleBindings created on behalf of this ProjectHelmChart in the Project Release Namespace based on Roles created in the
 // Project Release Namespace and RoleBindings attached to the default operator roles (configured as AdminClusterRole, EditClusterRole, and ViewClusterRole
-//  in the providedRuntimeOptions) in the Project Registration Namespace only. To update these RoleBindings in the release namespace, you will need to assign
+//
+//	in the providedRuntimeOptions) in the Project Registration Namespace only. To update these RoleBindings in the release namespace, you will need to assign
+//
 // additional permissions to the default roles in the Project Registration Namespace or manually assign RoleBindings in the release namespace.
 func (h *handler) getRoleBindings(projectID string, k8sRoleToRoleRefs map[string][]rbacv1.RoleRef, k8sRoleToSubjects map[string][]rbacv1.Subject, projectHelmChart *v1alpha1.ProjectHelmChart) []runtime.Object {
 	var objs []runtime.Object


### PR DESCRIPTION
- Also includes changes to fix `fmt` errors 
- Adds `staticcheck` to check for deprecated modules (`io/ioutil` in this case)