### PR TITLE
Do not return error in ProjectGetter when namespaces don't exist

### DIFF
--- a/charts/helm-project-operator/Chart.yaml
+++ b/charts/helm-project-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: helm-project-operator
 description: Helm Project Operator
-version: 0.1.1
-appVersion: 0.1.0
+version: 0.1.2
+appVersion: 0.1.1
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Helm Project Operator

--- a/charts/helm-project-operator/values.yaml
+++ b/charts/helm-project-operator/values.yaml
@@ -128,7 +128,7 @@ namespaceOverride: ""
 
 image:
   repository: rancher/helm-project-operator
-  tag: v0.1.0
+  tag: v0.1.1
   pullPolicy: IfNotPresent
 
 helmController:


### PR DESCRIPTION
Related Issue: https://github.com/rancher/helm-project-operator/issues/43

Since ProjectGetter methods are called by the indexers, if the methods return errors on namespaces not existing, it can result in a panic due to the default behavior of the [thread_safe_store.go](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go#L148-L153).

This would only happen in situations where there's an extremely large amount of load on the Prometheus Federator, since normally indexing is a fairly quick operation that should happen before a namespace can be created and deleted (unless the controllers are heavily backed up in processing).