### PR TITLE
Do not ever return an error for indexers

### DIFF
--- a/charts/helm-project-operator/Chart.yaml
+++ b/charts/helm-project-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: helm-project-operator
 description: Helm Project Operator
-version: 0.1.2
-appVersion: 0.1.1
+version: 0.2.0
+appVersion: 0.2.0
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Helm Project Operator

--- a/charts/helm-project-operator/values.yaml
+++ b/charts/helm-project-operator/values.yaml
@@ -128,7 +128,7 @@ namespaceOverride: ""
 
 image:
   repository: rancher/helm-project-operator
-  tag: v0.1.1
+  tag: v0.2.0
   pullPolicy: IfNotPresent
 
 helmController:

--- a/pkg/controllers/namespace/getter.go
+++ b/pkg/controllers/namespace/getter.go
@@ -15,10 +15,10 @@ import (
 // ProjectGetter allows you to get target namespaces based on a project and identify namespaces as special namespaces in a project
 type ProjectGetter interface {
 	// IsProjectRegistrationNamespace returns whether to watch for ProjectHelmCharts in the provided namespace
-	IsProjectRegistrationNamespace(namespace string) (bool, error)
+	IsProjectRegistrationNamespace(namespace *corev1.Namespace) bool
 
 	// IsSystemNamespace returns whether the provided namespace is considered a system namespace
-	IsSystemNamespace(namespace string) (bool, error)
+	IsSystemNamespace(namespace *corev1.Namespace) bool
 
 	// GetTargetProjectNamespaces returns the list of namespaces that should be targeted for a given ProjectHelmChart
 	// Any namespace returned by this should not be a project registration namespace or a system namespace
@@ -129,29 +129,13 @@ type projectGetter struct {
 }
 
 // IsProjectRegistrationNamespace returns whether to watch for ProjectHelmCharts in the provided namespace
-func (g *projectGetter) IsProjectRegistrationNamespace(namespace string) (bool, error) {
-	namespaceObj, err := g.namespaces.Get(namespace, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// A non-existent namespace is not a project registration namespace
-			return false, nil
-		}
-		return false, err
-	}
-	return g.isProjectRegistrationNamespace(namespaceObj), nil
+func (g *projectGetter) IsProjectRegistrationNamespace(namespace *corev1.Namespace) bool {
+	return g.isProjectRegistrationNamespace(namespace)
 }
 
 // IsSystemNamespace returns whether the provided namespace is considered a system namespace
-func (g *projectGetter) IsSystemNamespace(namespace string) (bool, error) {
-	namespaceObj, err := g.namespaces.Get(namespace, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// A non-existent namespace is not a system namespace
-			return false, nil
-		}
-		return false, err
-	}
-	return g.isSystemNamespace(namespaceObj), nil
+func (g *projectGetter) IsSystemNamespace(namespace *corev1.Namespace) bool {
+	return g.isSystemNamespace(namespace)
 }
 
 // GetTargetProjectNamespaces returns the list of namespaces that should be targeted for a given ProjectHelmChart

--- a/pkg/controllers/project/cleanup.go
+++ b/pkg/controllers/project/cleanup.go
@@ -29,10 +29,7 @@ func (h *handler) initRemoveCleanupLabels() error {
 			continue
 		}
 		for _, projectHelmChart := range projectHelmChartList.Items {
-			shouldManage, err := h.shouldManage(&projectHelmChart)
-			if err != nil {
-				return err
-			}
+			shouldManage := h.shouldManage(&projectHelmChart)
 			if !shouldManage {
 				// not a valid ProjectHelmChart for this operator
 				continue

--- a/pkg/controllers/project/resolvers.go
+++ b/pkg/controllers/project/resolvers.go
@@ -95,10 +95,11 @@ func (h *handler) resolveProjectRegistrationNamespaceData(namespace, name string
 }
 
 func (h *handler) resolveProjectRegistrationNamespaceRoleBinding(namespace, name string, rb *rbacv1.RoleBinding) ([]relatedresource.Key, error) {
-	isProjectRegistrationNamespace, err := h.projectGetter.IsProjectRegistrationNamespace(namespace)
+	namespaceObj, err := h.namespaceCache.Get(namespace)
 	if err != nil {
 		return nil, err
 	}
+	isProjectRegistrationNamespace := h.projectGetter.IsProjectRegistrationNamespace(namespaceObj)
 	if !isProjectRegistrationNamespace {
 		return nil, nil
 	}
@@ -141,10 +142,7 @@ func (h *handler) resolveClusterRoleBinding(namespace, name string, crb *rbacv1.
 		if namespace == nil {
 			continue
 		}
-		isProjectRegistrationNamespace, err := h.projectGetter.IsProjectRegistrationNamespace(namespace.Name)
-		if err != nil {
-			return nil, err
-		}
+		isProjectRegistrationNamespace := h.projectGetter.IsProjectRegistrationNamespace(namespace)
 		if !isProjectRegistrationNamespace {
 			continue
 		}


### PR DESCRIPTION
This is a minor refactor to ensure that our indexers **never** return errors.

This is done by modifying the signature of the ProjectGetter, which prevents the role binding indexer from panicking.

This also allows us to refactor shouldManage to not return an error, which prevents the projectHelmChart indexer from panicking.

With these fixes, indexer should no longer be able to throw panics.

Since we are modifying a function signature, this change is being targeted for **v0.2.0**.